### PR TITLE
Make WASP compatible with OTB 7.0

### DIFF
--- a/CompositePreprocessing/include/MaskExtractorFilter.h
+++ b/CompositePreprocessing/include/MaskExtractorFilter.h
@@ -29,7 +29,7 @@
 #include "otbWrapperTypes.h"
 #include "otbMultiToMonoChannelExtractROI.h"
 #include "otbImageFileReader.h"
-#include "otbUnaryFunctorImageFilter.h"
+#include "itkUnaryFunctorImageFilter.h"
 #include "MaskExtractorFunctor.h"
 
 #include "itkNumericTraits.h"

--- a/CompositePreprocessing/src/CompositePreprocessing.cpp
+++ b/CompositePreprocessing/src/CompositePreprocessing.cpp
@@ -70,7 +70,6 @@ private:
 		SetName("CompositePreprocessing");
 		SetDescription("Perform the directional correction of FRE Images");
 
-		SetDocName("CompositePreprocessing");
 		SetDocLongDescription("Perform the directional correction of FRE Images");
 		SetDocLimitations("None");
 		SetDocAuthors("Peter KETTIG");

--- a/ProductFormatter/src/ProductFormatter.cpp
+++ b/ProductFormatter/src/ProductFormatter.cpp
@@ -64,7 +64,6 @@ private:
 		SetName("ProductFormatter");
 		SetDescription("Creates the final output product using the previously generated files from UpdateSynthesis as well as all Metadata Information");
 
-		SetDocName("ProductFormatter");
 		SetDocLongDescription("Creates the final output product using the previously generated files from UpdateSynthesis as well as all Metadata Information");
 		SetDocLimitations("None");
 		SetDocAuthors("Peter KETTIG, CNES");

--- a/UpdateSynthesis/src/UpdateSynthesis.cpp
+++ b/UpdateSynthesis/src/UpdateSynthesis.cpp
@@ -88,7 +88,6 @@ private:
 		SetName("UpdateSynthesis");
 		SetDescription("Update synthesis using the recurrent expression of the weighted average.");
 
-		SetDocName("UpdateSynthesis");
 		SetDocLongDescription("Update synthesis using the recurrent expression of the weighted average.");
 		SetDocLimitations("None");
 		SetDocAuthors("Peter KETTIG");
@@ -251,8 +250,8 @@ private:
 				auto spacingPrevL3A = L2AImage->GetSpacing();
 
 				if((nL3AWidth != nL2AWidth) || (nL3AHeight != nL2AHeight)) {
-					otbMsgDevMacro("WARNING: L3A and L2A product sizes differ: " << "L2A: " << nL2AWidth << " " << nL2AHeight << ", "
-							<< "L3A: " << nL3AWidth << " " << nL3AHeight << std::endl;)
+        otbMsgDevMacro(<<"WARNING: L3A and L2A product sizes differ: " << "L2A: " << nL2AWidth << " " << nL2AHeight << ", "
+                       << "L3A: " << nL3AWidth << " " << nL3AHeight);
 				}
 				InternalBandImageType::Pointer weights = ResampledBandsExtractor.ExtractImgResampledBand(prevL3A, 1, Interpolator_Linear, spacingPrevL3A[0], spacingL2A[0], nDesiredWidth, nDesiredHeight);
 				rasterList->PushBack(weights);
@@ -284,8 +283,8 @@ private:
 				auto spacingPrevL3A = L2AImage->GetSpacing();
 
 				if((nL3AWidth != nL2AWidth) || (nL3AHeight != nL2AHeight)) {
-					otbMsgDevMacro("WARNING: L3A and L2A product sizes differ: " << "L2A: " << nL2AWidth << " " << nL2AHeight << ", "
-							<< "L3A: " << nL3AWidth << " " << nL3AHeight << std::endl;)
+        otbMsgDevMacro(<<"WARNING: L3A and L2A product sizes differ: " << "L2A: " << nL2AWidth << " " << nL2AHeight << ", "
+                       << "L3A: " << nL3AWidth << " " << nL3AHeight);
 				}
 				int nL3Weights = ResampledBandsExtractor.ExtractAllResampledBands(prevL3AWeight, rasterList, Interpolator_Linear, spacingPrevL3A[0], spacingL2A[0], nDesiredWidth, nDesiredHeight);
 				int nL3Dates= ResampledBandsExtractor.ExtractAllResampledBands(prevL3AAvgDate, rasterList, Interpolator_Linear, spacingPrevL3A[0], spacingL2A[0], nDesiredWidth, nDesiredHeight);

--- a/WeightCalculation/TotalWeight/src/TotalWeight.cpp
+++ b/WeightCalculation/TotalWeight/src/TotalWeight.cpp
@@ -65,7 +65,6 @@ private:
     SetName("TotalWeight");
     SetDescription("Calculate the total weight using the AOT- and cloud-images");
 
-    SetDocName("Total Weight Computation");
     SetDocLongDescription("Calculate the total weight using the AOT- and cloud-images");
 
     SetDocLimitations("None");

--- a/WeightCalculation/WeightAOT/src/WeightAOT.cpp
+++ b/WeightCalculation/WeightAOT/src/WeightAOT.cpp
@@ -64,7 +64,6 @@ private:
     SetName("WeightAOT");
     SetDescription("Calculate the AOT-weight from a given AOT-mask");
 
-    SetDocName("WeightAOT");
     SetDocLongDescription("Calculate the AOT-weight from a given AOT-mask");
     SetDocLimitations("None");
     SetDocAuthors("Peter Kettig");

--- a/WeightCalculation/WeightOnClouds/src/WeightOnClouds.cpp
+++ b/WeightCalculation/WeightOnClouds/src/WeightOnClouds.cpp
@@ -71,7 +71,6 @@ private:
 		SetName("WeightOnClouds");
 		SetDescription("Computes the cloud weight value for the given mask cloud and parameters");
 
-		SetDocName("Weight on Clouds");
 		SetDocLongDescription("Computes the cloud weight value for the given mask cloud and parameters");
 
 		SetDocLimitations("None");


### PR DESCRIPTION
Fixes:
- otb::UnaryFunctorImageFilter does not exist anymore
- SetDocName() does not exist anymore in otb::Wrappers::Application
- Logging macro changed

Those should not break compatibility with previous OTB versions.