### PR TITLE
Filter dates that are not within target date +/- synthalf

### DIFF
--- a/PythonScripts/WASP.py
+++ b/PythonScripts/WASP.py
@@ -168,7 +168,7 @@ class TemporalSynthesis():
                 raise NameError("Cannot find {0} in the list of OTB Apps".format(item))
         return
 
-    def getAcquisitionPeriod(self, xmllist):
+    def getAcquisitionPeriod(self, xmllist, synthalf = None, date = None):
         """
         @brief Calculate Min, Max and Middle-datetimes from a Muscate-XML list
         @param xmllist the list of filenames containing an XML
@@ -196,6 +196,24 @@ class TemporalSynthesis():
             logging.error("Dates list empty. Are all XMLs readable?")
             exit(1)
         dates.sort()
+        
+        print("Nb date before filtering: {}".format(len(dates)))
+
+        # Filter date that are not within synthalf range
+        if synthalf is not None and date is not None:
+            date = self.stringToDatetime(args.date, short = True)
+            synthalf_delta = dt.timedelta(days = synthalf)
+            
+            filtered_dates = []
+
+            for d in dates:
+                if abs(d-date) <= synthalf_delta:
+                    filtered_dates.append(d)
+                else:
+                    logging.info("Removing {} date because it is outside of target date {} +/- {} days".format(d,date,synthalf))
+            dates = filtered_dates
+            
+        print("Nb date after filtering: {}".format(len(dates)))
         minDate = min(dates)
         maxDate = max(dates)
         midDate = minDate + (maxDate - minDate)/2
@@ -319,7 +337,7 @@ class TemporalSynthesis():
             self.setParameterVersion(args.version)
 
         #Calculate temporal parameters
-        acqPeriod, synthalf, datesAsDatetime = self.getAcquisitionPeriod(args.input)
+        acqPeriod, synthalf, datesAsDatetime = self.getAcquisitionPeriod(args.input, args.synthalf, args.date)
         #Set temporal parameters to either default values or to user-defined ones
         if(args.date == None):
             args.date = self.datetimeToString(acqPeriod[1])

--- a/PythonScripts/WASP.py
+++ b/PythonScripts/WASP.py
@@ -196,12 +196,11 @@ class TemporalSynthesis():
             logging.error("Dates list empty. Are all XMLs readable?")
             exit(1)
         dates.sort()
-        
-        print("Nb date before filtering: {}".format(len(dates)))
 
         # Filter date that are not within synthalf range
         if synthalf is not None and date is not None:
             date = self.stringToDatetime(args.date, short = True)
+            logging.info("Filtering dates outside of target date {} +/- {} days".format(date,synthalf))
             synthalf_delta = dt.timedelta(days = synthalf)
             
             filtered_dates = []
@@ -209,11 +208,9 @@ class TemporalSynthesis():
             for d in dates:
                 if abs(d-date) <= synthalf_delta:
                     filtered_dates.append(d)
-                else:
-                    logging.info("Removing {} date because it is outside of target date {} +/- {} days".format(d,date,synthalf))
             dates = filtered_dates
-            
-        print("Nb date after filtering: {}".format(len(dates)))
+            logging.info("{} dates kept for synthesis".format(len(dates)))
+
         minDate = min(dates)
         maxDate = max(dates)
         midDate = minDate + (maxDate - minDate)/2

--- a/PythonScripts/WASP.py
+++ b/PythonScripts/WASP.py
@@ -195,7 +195,6 @@ class TemporalSynthesis():
         if(not dates):
             logging.error("Dates list empty. Are all XMLs readable?")
             exit(1)
-        dates.sort()
 
         # Filter date that are not within synthalf range
         if synthalf is not None and date is not None:
@@ -204,12 +203,16 @@ class TemporalSynthesis():
             synthalf_delta = dt.timedelta(days = synthalf)
             
             filtered_dates = []
-
-            for d in dates:
+            filtered_xmllist = []
+            for xml,d in zip(xmllist,dates):
                 if abs(d-date) <= synthalf_delta:
                     filtered_dates.append(d)
+                    filtered_xmllist.append(xml)
             dates = filtered_dates
+            xmllist = filtered_xmllist
             logging.info("{} dates kept for synthesis".format(len(dates)))
+
+        dates.sort()
 
         minDate = min(dates)
         maxDate = max(dates)
@@ -220,7 +223,7 @@ class TemporalSynthesis():
         elif(dateIntervals[0] > MAX_DATE_INTERVAL or dateIntervals[1] > MAX_DATE_INTERVAL):
             logging.warning("XML-Input dates interval is bigger than " + str(MAX_DATE_INTERVAL*2 - 1) + " days!")
 
-        return [minDate, midDate, maxDate],  np.mean(dateIntervals), dates
+        return [minDate, midDate, maxDate],  np.mean(dateIntervals), dates, xmllist
 
     def datetimeToString(self, d, short = False):
         """
@@ -334,7 +337,9 @@ class TemporalSynthesis():
             self.setParameterVersion(args.version)
 
         #Calculate temporal parameters
-        acqPeriod, synthalf, datesAsDatetime = self.getAcquisitionPeriod(args.input, args.synthalf, args.date)
+        acqPeriod, synthalf, datesAsDatetime, xmllist = self.getAcquisitionPeriod(args.input, args.synthalf, args.date)
+        args.input = xmllist
+
         #Set temporal parameters to either default values or to user-defined ones
         if(args.date == None):
             args.date = self.datetimeToString(acqPeriod[1])


### PR DESCRIPTION
This PR adds date filtering when command-line parameters `--date` and `--synthalf` are both set.

Dates outside of date +/- synthalf are ignored by the processor.